### PR TITLE
Postamble based implementation (proof of concept, do not apply)

### DIFF
--- a/lib/Inline/Module/MakeMaker.pm
+++ b/lib/Inline/Module/MakeMaker.pm
@@ -23,6 +23,7 @@ our @EXPORT = qw(FixMakefile);
 
 sub default_args {
     my ($self, $args) = @_;
+    $args = $args->{inline} or die;
     $args->{module} = $self->{NAME} unless $args->{module};
     $args->{module} = [ $args->{module} ] unless ref $args->{module};
     $args->{inline} ||= [ map "${_}::Inline", @{$args->{module}} ];


### PR DESCRIPTION
This is an implementation of the MakeMaker necesseties based on a postamble. The I::M I::M::MM merge last night means this would need to be rewritten extensively though (I didn't see that until I had finished this).
