### PR TITLE
`handle_distdir` now returns a list of files added

### DIFF
--- a/lib/Inline/Module.pm
+++ b/lib/Inline/Module.pm
@@ -277,7 +277,7 @@ sub handle_distdir {
         push @included_modules, $_;
     }
 
-    my @manifest;
+    my @manifest; # files created under distdir
     for my $module (@inlined_modules) {
         my $code = $class->dyna_module($module);
         $class->write_module("$distdir/lib", $module, $code);
@@ -294,6 +294,8 @@ sub handle_distdir {
     }
 
     $class->add_to_manifest($distdir, @manifest);
+
+    return @manifest; # return a list of the files added
 }
 
 sub handle_fixblib {


### PR DESCRIPTION
This is so that other tools can know which files were added. In the case
of `Dist::Zilla`, it needs to know the files so that it can add them to
the release tarball.
