### PR TITLE
dyna_module now generates empty POD to make Pod::Coverage happy.

### DIFF
--- a/lib/Inline/Module.pm
+++ b/lib/Inline/Module.pm
@@ -362,6 +362,10 @@ package $module;
 use base 'DynaLoader';
 bootstrap $module;
 1;
+
+=pod
+
+=cut
 ...
 
 # TODO: Add XS VERSION checking support:


### PR DESCRIPTION
This commit solves the problem with Pod::Coverage described in https://github.com/ingydotnet/inline-module-pm/issues/33