### PR TITLE
provide an empty import method in the generated module

### DIFF
--- a/lib/Inline/Module.pm
+++ b/lib/Inline/Module.pm
@@ -361,6 +361,7 @@ use strict; use warnings;
 package $module;
 use base 'DynaLoader';
 bootstrap $module;
+sub import {}
 1;
 ...
 


### PR DESCRIPTION
During development, the inline module is meant to be passed C code to compile. For a release, it is replaced with a module that already has the code compiled, so its import is meant to do nothing.

Future versions of perl are planned to throw errors if an undefined import method is given arguments, since this generally indicates a mistake.

Provide an empty import method to explicitly ignore the arguments.